### PR TITLE
feat: unique store slug

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
+    "slugify": "^1.6.6",
     "typeorm": "^0.3.17",
     "uuid": "^9.0.1"
   },

--- a/backend/src/modules/store-layout-details/entities/store-layout-details.entity.ts
+++ b/backend/src/modules/store-layout-details/entities/store-layout-details.entity.ts
@@ -36,6 +36,9 @@ export class StoreLayoutDetails {
   @Column('simple-json', { name: 'social_links', nullable: true })
   social_links: any;
 
+  @Column('text', { name: 'slug', nullable: true })
+  slug: string;
+
   @ManyToOne(() => Users, (users) => users.store_layout_details, {
     onDelete: 'NO ACTION',
     onUpdate: 'NO ACTION',

--- a/backend/src/modules/store-layout-details/store-layout-details.controller.ts
+++ b/backend/src/modules/store-layout-details/store-layout-details.controller.ts
@@ -10,6 +10,7 @@ import {
   Res,
   HttpStatus,
   NotFoundException,
+  Query,
 } from '@nestjs/common';
 import { StoreLayoutDetailsService } from './store-layout-details.service';
 import { CreateStoreLayoutDetailsInput } from './dto/create-store-layout-details.input';
@@ -43,12 +44,30 @@ export class StoreLayoutDetailsController {
       'Store layout details created successfully',
     );
   }
-
+  
   @Get()
   async findAll(@Res() res: Response) {
     const result = await this.storeLayoutDetailsService.find({
       relations: { store_layout_sliders: true },
     });
+    return baseController.getResult(
+      res,
+      HttpStatus.OK,
+      result,
+      'Store layout details fetched successfully',
+    );
+  }
+  
+  @SkipAuth()
+  @Get('search')
+  async findOneByName(@Res() res: Response, @Query('name') name: string) {
+    const trimmedName = name.trim();
+    console.log(trimmedName);
+    const result = await this.storeLayoutDetailsService.findOne({
+      where: { name: trimmedName },
+      relations: { store_layout_sliders: true },
+    });
+    
     return baseController.getResult(
       res,
       HttpStatus.OK,
@@ -62,6 +81,25 @@ export class StoreLayoutDetailsController {
   async findOne(@Res() res: Response, @Param('user_id') user_id: string) {
     const result = await this.storeLayoutDetailsService.findOne({
       where: { user_id },
+      relations: { store_layout_sliders: true },
+    });
+    if (!result) {
+      throw new NotFoundException('This record does not exist!');
+    }
+    return baseController.getResult(
+      res,
+      HttpStatus.OK,
+      result,
+      'Store layout details fetched successfully',
+    );
+  }
+
+
+  @SkipAuth()
+  @Get('slug/:slug')
+  async findOneBySlug(@Res() res: Response, @Param('slug') slug: string) {
+    const result = await this.storeLayoutDetailsService.findOne({
+      where: { slug },
       relations: { store_layout_sliders: true },
     });
     if (!result) {


### PR DESCRIPTION
Dodao kolunu u tabeli store_layout_details
name: slug
varchar(100)

Odraditi npm install

Napravio proveru kada se kreira ili updejtuje prodavnica, da li postoji sa takvim nazivom
Ovo je takodje potrebno hendlovati na frontu (Back vraca error message)

Napravio api pozive za dohvatanje informacija o prodavnici po name-u i slug-u

Api pozivi:

Pretraga po imenu: /store_layout_details/search?name=IME_PRODAVNICE
Pretraga po slug-u /store_layout_details/slug/:slug (Ovo zapravo treba da se koriste umesto one pretrage po ID-u na frontu)

Potrebno je rucno dodati slug-ove u bazu, jer trenutno ni jedan store nema slug, ako je npr Anime Shop Srbija, slug ce biti anime-shop-srbija
ako je name Tv Shows, slug ce biti tv-shows, itd.